### PR TITLE
Add workaround to support Neovim

### DIFF
--- a/plugin/osc52.vim
+++ b/plugin/osc52.vim
@@ -99,7 +99,9 @@ endfun
 function! s:rawecho(str)
   let redraw = get(g:, 'osc52_redraw', 2)
   let print  = get(g:, 'osc52_print', 'echo')
-  if print == 'echo'
+  if has('nvim')
+    call chansend(v:stderr, a:str)
+  elseif print == 'echo'
     exe "silent! !echo" shellescape(a:str)
   elseif print == 'printf'
     exe "silent! !printf \\%s" shellescape(a:str)


### PR DESCRIPTION
Neovim cannot access `/dev/tty` since 0.3.0 which is needed for OSC52 support: see https://github.com/neovim/neovim/issues/8450. This PR adds the workaround suggested in the issue. This closes #6.